### PR TITLE
Pin foreign_keys=OFF for the migration connection

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -177,6 +177,13 @@ async def get_db():
 
 
 async def _run_migrations(db):
+    # Migrations must run with FK enforcement OFF. Table rebuilds (CREATE new →
+    # copy → DROP old → RENAME) fail under foreign_keys=ON whenever another table
+    # holds references to the rebuilt one (e.g. requests.requested_by_user_id →
+    # users.id) — and only on POPULATED databases, so fresh-DB test runs never see
+    # it. Plain connections default to OFF, but get_db() turns it ON: pin it here
+    # so migrations stay correct no matter what connection they are handed.
+    await db.execute("PRAGMA foreign_keys=OFF")
     row = await (await db.execute("PRAGMA user_version")).fetchone()
     current = row[0]
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -37,6 +37,24 @@ async def test_all_tables_created(db_path):
         assert EXPECTED_TABLES <= tables
 
 
+async def test_migrations_disable_fk_enforcement_on_any_connection(tmp_path):
+    """Table-rebuild migrations (CREATE new -> copy -> DROP old -> RENAME) fail
+    under foreign_keys=ON when other tables reference the rebuilt one — but only
+    on populated databases, so a suite that migrates empty DBs never catches it.
+    _run_migrations must pin FK enforcement OFF itself rather than inherit
+    whatever the caller's connection has set."""
+    from app.database import _run_migrations
+    path = str(tmp_path / "fk-on.db")
+    async with aiosqlite.connect(path) as db:
+        await db.execute("PRAGMA foreign_keys=ON")
+        await _run_migrations(db)
+        row = await (await db.execute("PRAGMA foreign_keys")).fetchone()
+        assert row[0] == 0  # the runner pinned it OFF for its own connection
+        tables = {r[0] for r in await (await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'")).fetchall()}
+        assert "users" in tables  # migrations actually ran to completion
+
+
 async def test_migrations_are_idempotent(tmp_path, monkeypatch):
     """Running init_db() twice on the same DB must not raise or corrupt schema."""
     path = str(tmp_path / "idempotent.db")


### PR DESCRIPTION

Makes explicit a latent hazard spotted during the #15 review (credit to the observation there): a table-rebuild migration (CREATE new → copy → DROP old → RENAME) fails on the `DROP` under `foreign_keys=ON` when other tables hold references into the rebuilt one **and** referencing rows exist — e.g. `requests.requested_by_user_id` → `users.id`. Today rebuilds would work only because `init_db()` happens to hand `_run_migrations` a plain connection, where SQLite defaults to `foreign_keys=OFF`; `get_db()` sets `foreign_keys=ON`. So the correctness is inherited from connection plumbing, and rerouting migrations through a `get_db()`-style connection would break only on populated databases — an initialization test that migrates empty databases never exercises the failure.

## What

`PRAGMA foreign_keys=OFF` as the first statement of `_run_migrations`, with a comment explaining why it must stay, plus a test that hands the runner a connection with `foreign_keys=ON` and asserts the runner pins it OFF (the test fails with the line removed). Two details that keep this sound:

- The pragma is issued before any DML, so it cannot hit SQLite's rule that `foreign_keys` changes are ignored inside an open transaction.
- The migration connection is dedicated: `init_db()` opens it, runs migrations, and closes it immediately, so enforcement-OFF never leaks into ordinary application writes (`get_db()` connections still set `foreign_keys=ON`).

## Scope

No migration on `main` today fails without this — it's insurance, not a bug fix. The first rebuild migration arrives with #15 (the `users` table rebuild), which is exactly why the requirement should be explicit rather than inherited. Independent of #15: branched from current `main`, and a three-way merge against #15's branch was checked in both orders with no conflicts. Full suite on this branch: 168 passed.
